### PR TITLE
Added googlebot, bingbot, yandex to list of user agents being checked

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -28,9 +28,10 @@ return [
         // Prerender service URL
         'prerender_url' => 'http://service.prerender.io',
 
-        // Some widely used crawler user agents (Google Bot, Yahoo and BingBot are not in this list because
-        // we support _escaped_fragment_ and want to ensure people aren't penalized for cloaking).
         'crawler_user_agents' => [
+            'googlebot',
+            'bingbot',
+            'yandex',
             'baiduspider',
             'facebookexternalhit',
             'twitterbot',

--- a/tests/ZfrPrerenderTest/Factory/ModuleOptionsFactoryTest.php
+++ b/tests/ZfrPrerenderTest/Factory/ModuleOptionsFactoryTest.php
@@ -36,7 +36,7 @@ class ModuleOptionsFactoryTest extends TestCase
         $options        = $serviceManager->get('ZfrPrerender\Options\ModuleOptions');
 
         $expectedCrawlerUserAgents = [
-            'baiduspider', 'facebookexternalhit', 'twitterbot', 'rogerbot', 'linkedinbot',
+            'googlebot', 'bingbot', 'yandex', 'baiduspider', 'facebookexternalhit', 'twitterbot', 'rogerbot', 'linkedinbot',
             'embedly', 'bufferbot', 'quora link preview', 'showyoubot', 'outbrain'
         ];
 


### PR DESCRIPTION
Google now follows what they call "Dynamic Rendering" where they allow you to serve prerendered pages directly to Googlebot based on a user agent check.

We've also verified with Bing support that bing supports dynamic rendering based on a user agent check as well.

You can find more information on Google's Dynamic Rendering here: https://prerender.io/documentation/google-support

@bakura10 I know it's been a while, but could you merge this simple change? Thanks so much!